### PR TITLE
Make sure f_score is a consecutive list at all times

### DIFF
--- a/a-star.lua
+++ b/a-star.lua
@@ -91,7 +91,8 @@ function remove_node ( set, theNode )
 
 	for i, node in ipairs ( set ) do
 		if node == theNode then 
-			set [ i ] = nil
+			set [ i ] = set [ #set ]
+			set [ #set ] = nil
 			break
 		end
 	end	


### PR DESCRIPTION
Since `f_score` is iterated over using `ipairs()`, it must always be a consecutive list. Therefore, `remove_node()` must not leave a hole when removing an item from the list.
